### PR TITLE
fix(sidebar): ensure consistent sidebar toggling on narrow screens

### DIFF
--- a/apps/main/src/app/(main)/Shell/MainAppShell.tsx
+++ b/apps/main/src/app/(main)/Shell/MainAppShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AppShell, Burger, Group, Title } from '@mantine/core';
+import { AppShell, Burger, Group, Title, useMantineTheme } from '@mantine/core';
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { Notifications } from '@mantine/notifications';
 import Link from 'next/link';
@@ -18,7 +18,8 @@ export default function MainAppShell({
   sidebar?: React.ReactElement<ComponentProps<typeof Sidebar>>;
 }) {
   const [opened, { toggle }] = useDisclosure();
-  const isMobile = useMediaQuery('(max-width: 768px)');
+  const theme = useMantineTheme();
+  const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
 
   const handleLinkClick = () => {
     if (isMobile) {

--- a/apps/main/src/app/(main)/Shell/Sidebar.test.tsx
+++ b/apps/main/src/app/(main)/Shell/Sidebar.test.tsx
@@ -1,38 +1,34 @@
 import { fireEvent, render, screen } from '@/test-utils';
-import { useMediaQuery } from '@mantine/hooks';
-import type { SidebarData } from './Sidebar';
 import Sidebar from './Sidebar';
+import { Event } from '@/datastore/schema';
 
-
-
-// Mock @mantine/hooks
-jest.mock('@mantine/hooks', () => ({
-  ...jest.requireActual('@mantine/hooks'),
-  useMediaQuery: jest.fn(),
-}));
-
-const mockData: SidebarData = {
+const mockData: { events: Event[] } = {
   events: [
     {
       id: 'event-1',
       path: 'organizations/org-1/series/series-1/events/event-1',
       name: 'Test Event 1',
+      start_date: new Date(),
+      end_date: new Date(),
+      description: '',
+      image_url: '',
+      instagram_url: '',
     },
     {
       id: 'event-2',
       path: 'organizations/org-1/series/series-1/events/event-2',
       name: 'Test Event 2',
+      start_date: new Date(),
+      end_date: new Date(),
+      description: '',
+      image_url: '',
+      instagram_url: '',
     },
   ],
 };
 
 describe('Sidebar component', () => {
-  beforeEach(() => {
-    (useMediaQuery as jest.Mock).mockClear();
-  });
-
   it('should render event links', () => {
-    (useMediaQuery as jest.Mock).mockReturnValue(false); // Default to not mobile
     render(<Sidebar {...mockData} />);
     expect(
       screen.getByRole('link', { name: 'Test Event 1' }),
@@ -42,23 +38,12 @@ describe('Sidebar component', () => {
     ).toBeInTheDocument();
   });
 
-  it('should call onLinkClick when a link is clicked on mobile', () => {
-    (useMediaQuery as jest.Mock).mockReturnValue(true); // Simulate mobile
+  it('should call onLinkClick when a link is clicked', () => {
     const onLinkClick = jest.fn();
     render(<Sidebar {...mockData} onLinkClick={onLinkClick} />);
 
     fireEvent.click(screen.getByRole('link', { name: 'Test Event 1' }));
 
     expect(onLinkClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not call onLinkClick when a link is clicked on desktop', () => {
-    (useMediaQuery as jest.Mock).mockReturnValue(false); // Simulate desktop
-    const onLinkClick = jest.fn();
-    render(<Sidebar {...mockData} onLinkClick={onLinkClick} />);
-
-    fireEvent.click(screen.getByRole('link', { name: 'Test Event 1' }));
-
-    expect(onLinkClick).not.toHaveBeenCalled();
   });
 });

--- a/apps/main/src/app/(main)/Shell/Sidebar.tsx
+++ b/apps/main/src/app/(main)/Shell/Sidebar.tsx
@@ -3,14 +3,7 @@
 import { toUrlPath } from '@/datastore/paths';
 import { Event } from '@/datastore/schema';
 import { ENV_DEBUG_LINKS } from '@/env/env';
-import {
-  Box,
-  Divider,
-  NavLink,
-  ScrollArea,
-  Stack,
-  useMantineTheme,
-} from '@mantine/core';
+import { Box, Divider, NavLink, ScrollArea, Stack } from '@mantine/core';
 import {
   IconBike,
   IconBug,
@@ -20,7 +13,6 @@ import {
 } from '@tabler/icons-react';
 import { usePathname } from 'next/navigation';
 import React from 'react';
-import { useMediaQuery } from '@mantine/hooks';
 import Link from 'next/link';
 
 interface SidebarProps {
@@ -30,11 +22,9 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ events, onLinkClick }) => {
   const pathname = usePathname();
-  const theme = useMantineTheme();
-  const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.sm})`);
 
   const handleLinkClick = () => {
-    if (isMobile && onLinkClick) {
+    if (onLinkClick) {
       onLinkClick();
     }
   };


### PR DESCRIPTION
The sidebar was not reliably opening and closing on narrow screens due to an inconsistent use of media queries. MainAppShell.tsx was using a hardcoded pixel value for the mobile breakpoint, while Sidebar.tsx was using the em-based value from the Mantine theme.

This commit fixes the issue by:
- Refactoring MainAppShell.tsx to use the sm breakpoint from the Mantine theme, ensuring consistency across components.
- Simplifying the click handler in Sidebar.tsx to remove the redundant mobile check.
- Updating the tests for Sidebar.tsx to reflect the refactored logic.