### PR TITLE
refactor: Unify avatar upload code

### DIFF
--- a/apps/main/src/app/(login)/new-user/NewUser.tsx
+++ b/apps/main/src/app/(login)/new-user/NewUser.tsx
@@ -4,6 +4,7 @@ import { userSchema } from '@/app/(main)/account/user-schema';
 import UserProfileCard from '@/components/cards/UpdateUserProfileCard';
 import { FormActionResult } from '@/components/forms/forms';
 import { useActionForm } from '@/components/forms/useActionForm';
+import { useAvatarUpload } from '@/components/forms/useAvatarUpload';
 import { useUserContext } from '@/user/client/UserContext';
 import {
   Box,
@@ -20,7 +21,6 @@ import {
 } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { redirect, useRouter } from 'next/navigation';
-import { useAvatarUpload } from '@/components/forms/useAvatarUpload';
 import { NewUserOptions } from './new-user-action';
 
 export default function NewUser({

--- a/apps/main/src/app/(main)/account/Account.tsx
+++ b/apps/main/src/app/(main)/account/Account.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useActionForm } from '@/components/forms/useActionForm';
 import { logout } from '@/auth/client/auth';
-import { FormActionResult } from '@/components/forms/forms';
 import UpdateUserProfileCard from '@/components/cards/UpdateUserProfileCard';
+import { FormActionResult } from '@/components/forms/forms';
+import { useActionForm } from '@/components/forms/useActionForm';
+import { useAvatarUpload } from '@/components/forms/useAvatarUpload';
 import { toUrlPath } from '@/datastore/paths';
 import { User } from '@/datastore/schema';
 import {
@@ -21,7 +22,6 @@ import {
 import { useDebouncedValue } from '@mantine/hooks';
 import { useRouter } from 'next/navigation';
 import { EditUserOptions } from './edit-user-action';
-import { useAvatarUpload } from '@/components/forms/useAvatarUpload';
 import { userSchema } from './user-schema';
 
 export interface AccountProps {

--- a/apps/main/src/app/(main)/account/upload-action.test.ts
+++ b/apps/main/src/app/(main)/account/upload-action.test.ts
@@ -6,8 +6,11 @@ import {
 import { verifyUserContext } from '@/user/server/user';
 import { randomUUID } from 'crypto';
 import { generateSignedUploadUrl } from './upload-action';
+<<<<<<< HEAD
 import { App } from 'firebase-admin/app';
 import { Storage } from '@google-cloud/storage';
+=======
+>>>>>>> 424dc2c (feat(profile): Add client-side avatar resizing and abuse protection)
 
 jest.mock('@/user/server/user');
 jest.mock('@/firebase/server/firebase-admin');
@@ -34,10 +37,17 @@ describe('generateSignedUploadUrl', () => {
       authUser: MOCK_AUTH_USER,
       user: null,
     });
+<<<<<<< HEAD
     mockedGetFirebaseAdminApp.mockResolvedValue({} as App);
     mockedGetFirebaseStorage.mockResolvedValue({
       bucket: () => mockBucket,
     } as unknown as Storage);
+=======
+    mockedGetFirebaseAdminApp.mockResolvedValue({} as any);
+    mockedGetFirebaseStorage.mockResolvedValue({
+      bucket: () => mockBucket,
+    } as any);
+>>>>>>> 424dc2c (feat(profile): Add client-side avatar resizing and abuse protection)
     mockedRandomUUID.mockReturnValue('test-photo-id');
     mockGetSignedUrl.mockResolvedValue(['https://fake-signed-url.com']);
   });


### PR DESCRIPTION
This commit introduces several improvements to the user profile avatar upload functionality.

- Implements client-side image resizing to 256x256 using `browser-image-compression` to reduce upload size and improve performance.
- Adds a file size limit of 2MB, enforced by both client-side validation and Firebase Storage security rules, to prevent abuse.
- Refactors the `editUserAction` to automatically delete the old avatar from Cloud Storage when a new one is uploaded, preventing orphaned files.
- Refactors the `UpdateUserProfileCard` to use a more modern UI pattern, displaying an 'Upload Photo' overlay on hover.
- Adds a new E2E test to verify the avatar overlay functionality.
- Fixes a bug in `editUserAction` where it was bypassing the `updateUser` function.
- Updates and adds unit tests to cover the new functionality and fixes.