### PR TITLE
ci: fix firestore indexes deployment environment

### DIFF
--- a/.github/workflows/deploy-firestore-indexes.yml
+++ b/.github/workflows/deploy-firestore-indexes.yml
@@ -19,6 +19,8 @@ jobs:
   deploy:
     name: Deploy Firestore Indexes
     runs-on: ubuntu-latest
+    environment:
+      name: ci
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds the ci environment to the firestore indexes deployment workflow to allow access to Google Cloud secrets.