### PR TITLE
fix: resolve 500 internal server error on /home due to unvalidated legacy data

### DIFF
--- a/apps/main/src/components/LiveContributionFeed/LiveContributionFeedItem.tsx
+++ b/apps/main/src/components/LiveContributionFeed/LiveContributionFeedItem.tsx
@@ -42,19 +42,28 @@ export const LiveContributionFeedItem = memo(function LiveContributionFeedItem({
           to{' '}
           <Text
             component={Link}
-            href={`/view/${toUrlPath(contribution.preemBrief.path)}`}
+            href={
+              contribution.preemBrief?.path
+                ? `/view/${toUrlPath(contribution.preemBrief.path)}`
+                : '#'
+            }
             style={{ textDecoration: 'none', color: 'inherit' }}
           >
-            &quot;{contribution.preemBrief.name}&quot;
+            &quot;{contribution.preemBrief?.name ?? 'Unknown Preem'}&quot;
           </Text>{' '}
           in the{' '}
           <Text
             component={Link}
-            href={`/view/${toUrlPath(contribution.preemBrief.raceBrief.path)}`}
+            href={
+              contribution.preemBrief?.raceBrief?.path
+                ? `/view/${toUrlPath(contribution.preemBrief.raceBrief.path)}`
+                : '#'
+            }
             fw={600}
             style={{ textDecoration: 'none', color: 'inherit' }}
           >
-            &quot;{contribution.preemBrief.raceBrief.name}&quot;
+            &quot;{contribution.preemBrief?.raceBrief?.name ?? 'Unknown Race'}
+            &quot;
           </Text>{' '}
           race!
         </Text>

--- a/apps/main/src/components/cards/PreemCard.tsx
+++ b/apps/main/src/components/cards/PreemCard.tsx
@@ -73,21 +73,25 @@ export function PreemCard({
     subheadings.push(
       <Text c="dimmed" key="brief">
         Part of{' '}
-        {showRace && (
+        {showRace && preem.raceBrief?.path && (
           <Anchor
             component={Link}
             href={`/view/${toUrlPath(preem.raceBrief.path)}`}
           >
-            {preem.raceBrief.name}
+            {preem.raceBrief.name ?? 'Unknown Race'}
           </Anchor>
         )}
-        {showRace && showEvent && ' at '}
-        {showEvent && (
+        {showRace &&
+          preem.raceBrief?.path &&
+          showEvent &&
+          preem.raceBrief?.eventBrief?.path &&
+          ' at '}
+        {showEvent && preem.raceBrief?.eventBrief?.path && (
           <Anchor
             component={Link}
             href={`/view/${toUrlPath(preem.raceBrief.eventBrief.path)}`}
           >
-            {preem.raceBrief.eventBrief.name}
+            {preem.raceBrief.eventBrief.name ?? 'Unknown Event'}
           </Anchor>
         )}
       </Text>,

--- a/apps/main/src/datastore/server/query/query.ts
+++ b/apps/main/src/datastore/server/query/query.ts
@@ -131,18 +131,24 @@ const getRacesForEvent = async (
   // Reconstruction
   const contributionsByPreemId = new Map<string, Contribution[]>();
   allContributions.forEach((c) => {
-    const pid = c.preemBrief.id;
-    if (!contributionsByPreemId.has(pid)) {
-      contributionsByPreemId.set(pid, []);
+    const pid = c.preemBrief?.id;
+    if (!pid) return;
+    let list = contributionsByPreemId.get(pid);
+    if (!list) {
+      list = [];
+      contributionsByPreemId.set(pid, list);
     }
-    contributionsByPreemId.get(pid)!.push(c);
+    list.push(c);
   });
 
   const preemsByRaceId = new Map<string, PreemWithContributions[]>();
   allPreems.forEach((p) => {
-    const rid = p.raceBrief.id;
-    if (!preemsByRaceId.has(rid)) {
-      preemsByRaceId.set(rid, []);
+    const rid = p.raceBrief?.id;
+    if (!rid) return;
+    let list = preemsByRaceId.get(rid);
+    if (!list) {
+      list = [];
+      preemsByRaceId.set(rid, list);
     }
     const children = contributionsByPreemId.get(p.id) || [];
     // Sort contributions by date descending (to match likely expectation, though original code had no explicit sort)
@@ -150,7 +156,7 @@ const getRacesForEvent = async (
     // If we want to be safe, we can sort by ID.
     children.sort((a, b) => a.id.localeCompare(b.id));
 
-    preemsByRaceId.get(rid)!.push({
+    list.push({
       preem: p,
       children: children,
     });


### PR DESCRIPTION
Added optional chaining to prevent 500 internal server errors caused by unvalidated legacy data missing deeply nested properties (like raceBrief).