### PR TITLE
fix: downgrade STRIPE_WEBHOOK_SECRET strict validation to a warning

### DIFF
--- a/apps/main/apphosting.yaml
+++ b/apps/main/apphosting.yaml
@@ -93,3 +93,5 @@ env:
     secret: SERVICE_ACCOUNT_PRIVATE_KEY
   - variable: STRIPE_API_KEY
     secret: STRIPE_API_KEY
+  - variable: STRIPE_WEBHOOK_SECRET
+    secret: STRIPE_WEBHOOK_SECRET

--- a/libs/env-vars/src/server/env.ts
+++ b/libs/env-vars/src/server/env.ts
@@ -71,8 +71,8 @@ export const validateServerEnv = () => {
         throw new Error('STRIPE_API_KEY is required when Stripe is enabled');
       }
       if (!parsed.STRIPE_WEBHOOK_SECRET) {
-        throw new Error(
-          'STRIPE_WEBHOOK_SECRET is required when Stripe is enabled',
+        console.warn(
+          '⚠️ STRIPE_WEBHOOK_SECRET is missing. Stripe Webhooks will fail.',
         );
       }
     }


### PR DESCRIPTION
Downgrades missing STRIPE_WEBHOOK_SECRET to a warning to prevent app crash on startup. Also adds STRIPE_WEBHOOK_SECRET to apphosting.yaml so the secret we just created gets injected.